### PR TITLE
Removed autocomplete and clear housenumber if not starting with a number

### DIFF
--- a/view/frontend/web/js/action/set-shipping-information-mixin.js
+++ b/view/frontend/web/js/action/set-shipping-information-mixin.js
@@ -55,6 +55,17 @@ define([
             if (shippingAddress['extension_attributes'] === undefined) {
                 shippingAddress['extension_attributes'] = {};
             }
+
+            const houseNumberInput = $('div[name="shippingAddress.custom_attributes.tig_housenumber"] input');
+            const hNValue = houseNumberInput.val();
+            const checkValid = hNValue.match(/^\d/);
+            if(!checkValid){
+                houseNumberInput.val('');
+                houseNumberInput.trigger('change');
+                houseNumberInput[0].scrollIntoView();
+                return false;
+            }
+
             // < M2.3.0
             if (shippingAddress.customAttributes !== undefined && shippingAddress.customAttributes.tig_housenumber !== undefined) {
                 shippingAddress['extension_attributes']['tig_housenumber']          = shippingAddress.customAttributes.tig_housenumber;

--- a/view/frontend/web/template/form/element/input-addition.html
+++ b/view/frontend/web/template/form/element/input-addition.html
@@ -15,4 +15,4 @@
         'aria-invalid': error() ? true : 'false',
         id: uid,
         disabled: disabled
-    }"  autocomplete="off" />
+    }"  autocomplete="unique-string-for-housenumber-addition" />

--- a/view/frontend/web/template/form/element/input.html
+++ b/view/frontend/web/template/form/element/input.html
@@ -9,10 +9,15 @@
     valueUpdate: 'keyup',
     hasFocus: focused,
     attr: {
+        maxLength: 5,
+        minLength: 1,
         name: inputName,
         placeholder: placeholder,
         'aria-required': required,
         'aria-invalid': error() ? true : 'false',
         id: uid,
         disabled: disabled
-    }"  autocomplete="off" />
+    }"
+       autocomplete="unique-string-for-housenumber"
+       id="unique-string-for-housenumber"
+/>


### PR DESCRIPTION
@hans2103 https://github.com/B2bZanden/OnderdelenExpertM2/issues/404
Je kan deze bugfix gaan uitrollen op de staging. 
Wat doet deze fix:

- Unique veldnamen toevoegen, waardoor autocomplete van chrome niet meer werkt
- Op het moment dat je probeert door te gaan naar de betalingsstap, wordt er een extra check gedaan op huisnummer. Indien huisnummer niet start met een getal, zal hij het veld leegmaken en een foutmelding geven dat deze niet correct is.